### PR TITLE
Improved performance by rasterizing layer

### DIFF
--- a/YIInnerShadowView/YIInnerShadowLayer.m
+++ b/YIInnerShadowView/YIInnerShadowLayer.m
@@ -17,6 +17,7 @@
         
         self.masksToBounds = YES;
         self.needsDisplayOnBoundsChange = YES;
+				self.shouldRasterize = YES;
         
         // Standard shadow stuff
         [self setShadowColor:[[UIColor colorWithWhite:0 alpha:1] CGColor]];


### PR DESCRIPTION
I have added three `YIInnerShadowView` objects to a scroll view and scrolling is not as smooth as it should be. I set the property `shouldRasterize` to YES and did the trick for me.
